### PR TITLE
className and htmlFor typo fixes in Cookie.jsx

### DIFF
--- a/src/components/Cookies.jsx
+++ b/src/components/Cookies.jsx
@@ -3,18 +3,18 @@ const Cookies = () => {
     return (
         <div>
             <input type="checkbox" id="showblock"/>
-            <div class="slideout">
-                <label class="slideout_tab" for="showblock" title="Help">
-                <span class="tab_text">
+            <div className="slideout">
+                <label className="slideout_tab" htmlFor="showblock" title="Help">
+                <span className="tab_text">
                     <span>Cookie Info</span>
                 </span>
                 </label>
-                <div class="slideout_content">
-                <div class="push_right">
-                    <p class="pst">Psst....<img class="cookie_img" src="https://lordicon.com/icons/wired/flat/2354-cookies.svg"/></p>
-                    <p class="cookie">We use Cookies to offer you a better browsing experience, analyse site traffic and personalize content.
+                <div className="slideout_content">
+                <div className="push_right">
+                    <p className="pst">Psst....<img className="cookie_img" src="https://lordicon.com/icons/wired/flat/2354-cookies.svg"/></p>
+                    <p className="cookie">We use Cookies to offer you a better browsing experience, analyse site traffic and personalize content.
                     </p>
-                    <p class="cookie">By continuing to browse TechByte Learning you will consent to our use of cookies.</p>
+                    <p className="cookie">By continuing to browse TechByte Learning you will consent to our use of cookies.</p>
                 </div>
                 </div>
             </div>


### PR DESCRIPTION
Just a quick typo fix regarding the console errors in Cookie.jsx. A few elements had 'for=' and 'class=' so I quickly updated them to remove the console errors.